### PR TITLE
Full Width + PDF Examples

### DIFF
--- a/_how-to-full-width.Rmd
+++ b/_how-to-full-width.Rmd
@@ -1,1 +1,31 @@
 ## Make a table full width
+
+By default, HTML tables span the full width of page, as seen in the example from section \@ref(create-a-basic-table):
+
+```{r}
+top_10_data %>% 
+  kable() 
+```
+
+You can specify `full_width = FALSE` in the `kable_styling` function to create more narrow tables. 
+
+```{r}
+
+top_10_data %>% 
+  kable() %>% 
+  kable_styling(full_width = FALSE)
+
+```
+
+For more control over column widths, you can alter the `width` argument of the `column_spec()` function. Below, we specify the width of the first column.
+
+```{r}
+
+top_10_data %>% 
+  kable() %>% 
+  kable_styling(full_width = FALSE) %>% 
+  column_spec(1, width = "30em")
+
+```
+
+Note that for PDF output, tables do **not** span the full width of the page by default. Thus, you must set `full_width = TRUE` in the `kable_styling` function. See the third example in section \@ref(take-advantage-of-pdf-only-features).

--- a/_how_to_pdf_only.Rmd
+++ b/_how_to_pdf_only.Rmd
@@ -40,6 +40,32 @@ top_10_data %>%
 include_graphics(path = "pdf_table_figures/ex_2.png")
 ```
 
+For PDF tables that are too long to fit on one page, you can specify `longtable = TRUE` in the `kable` function call to split the table across multiple pages. `kable_styling(latex_options = c("repeat_header"))`  adds the header row all subsequent pages containing the long table.
 
+```{r echo=1:13, eval=FALSE}
+library(tidyverse)
+library(fivethirtyeight)
+library(kableExtra)
 
+spi_global_rankings %>% 
+  filter(league %in% c("Spanish Primera Division", 
+                       "Barclays Premier League",
+                       "German Bundesliga",
+                       "Italy Serie A")) %>% 
+  arrange(rank) %>% 
+  kable(format = "latex", booktabs = TRUE, longtable = TRUE,
+        caption = "Global Club Soccer Rankings: Top Four Leagues") %>% 
+  kable_styling(latex_options = c("repeat_header"))
 
+spi_global_rankings %>% 
+  filter(league %in% c("Spanish Primera Division", 
+                       "Barclays Premier League",
+                       "German Bundesliga",
+                       "Italy Serie A")) %>% 
+  arrange(rank) %>% 
+  kable(format = "latex", booktabs = TRUE, longtable = TRUE,
+        caption = "Global Club Soccer Rankings: Top Four Leagues") %>% 
+  kable_styling(latex_options = c("repeat_header")) %>% 
+  save_kable(file = "pdf_table_figures/ex_3.png")
+include_graphics(path = "pdf_table_figures/ex_3.png")
+```

--- a/_how_to_pdf_only.Rmd
+++ b/_how_to_pdf_only.Rmd
@@ -40,9 +40,51 @@ top_10_data %>%
 include_graphics(path = "pdf_table_figures/ex_2.png")
 ```
 
+As mentioned in section \@ref(make-a-table-full-width), PDF tables do not span the full page width by default. You can set `full_width = TRUE` in `kable_styling` to change this behavior.
+
+```{r eval = FALSE}
+top_10_data %>% 
+  kable(format = "latex", booktabs = TRUE) %>% 
+  kable_styling(full_width = TRUE)
+
+```
+
+Sometimes, PDF tables with many columns may be too wide to fit on the page. In this case, you may also specify `latex_options = c("scale_down")` to shrink the table so it fits on the page. 
+
+```{r eval=FALSE}
+library(tidyverse)
+library(fivethirtyeight)
+library(kableExtra)
+
+spi_global_rankings %>% 
+  filter(rank <= 10) %>% 
+  mutate(text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam bibendum tristique placerat. Praesent commodo ut ipsum id condimentum. Vivamus faucibus nunc turpis, sit amet dictum sapien fermentum non. Donec quam felis, lobortis quis euismod sed, euismod eget mi. Praesent malesuada mi ligula, ut ultricies felis maximus at. Nullam et metus.") %>% 
+  kable(format = "latex", booktabs = TRUE, longtable = TRUE,
+        caption = "Global Club Soccer Rankings: Top 10 Clubs") %>% 
+  kable_styling(full_width = TRUE, latex_options = c("scale_down"))
+
+```
+
+However, `scale_down` does not work with `longtable` and shrinking the table may make the font too small. An alternative approach is to specify column widths using `column_spec` - this will just take a more "guess-and-check" approach.
+
+```{r eval=FALSE}
+library(tidyverse)
+library(fivethirtyeight)
+library(kableExtra)
+
+spi_global_rankings %>% 
+  filter(rank <= 10) %>% 
+  mutate(text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam bibendum tristique placerat. Praesent commodo ut ipsum id condimentum. Vivamus faucibus nunc turpis, sit amet dictum sapien fermentum non. Donec quam felis, lobortis quis euismod sed, euismod eget mi. Praesent malesuada mi ligula, ut ultricies felis maximus at. Nullam et metus.") %>% 
+  kable(format = "latex", booktabs = TRUE, longtable = TRUE,
+        caption = "Global Club Soccer Rankings: Top 10 Clubs") %>% 
+  column_spec(1:2, width = "5em") %>% 
+  column_spec(8, width = "15em")
+
+```
+
 For PDF tables that are too long to fit on one page, you can specify `longtable = TRUE` in the `kable` function call to split the table across multiple pages. `kable_styling(latex_options = c("repeat_header"))`  adds the header row all subsequent pages containing the long table.
 
-```{r echo=1:13, eval=FALSE}
+```{r eval=FALSE}
 library(tidyverse)
 library(fivethirtyeight)
 library(kableExtra)
@@ -54,18 +96,7 @@ spi_global_rankings %>%
                        "Italy Serie A")) %>% 
   arrange(rank) %>% 
   kable(format = "latex", booktabs = TRUE, longtable = TRUE,
-        caption = "Global Club Soccer Rankings: Top Four Leagues") %>% 
+        caption = "Global Club Soccer Rankings: Top 4 Leagues") %>% 
   kable_styling(latex_options = c("repeat_header"))
 
-spi_global_rankings %>% 
-  filter(league %in% c("Spanish Primera Division", 
-                       "Barclays Premier League",
-                       "German Bundesliga",
-                       "Italy Serie A")) %>% 
-  arrange(rank) %>% 
-  kable(format = "latex", booktabs = TRUE, longtable = TRUE,
-        caption = "Global Club Soccer Rankings: Top Four Leagues") %>% 
-  kable_styling(latex_options = c("repeat_header")) %>% 
-  save_kable(file = "pdf_table_figures/ex_3.png")
-include_graphics(path = "pdf_table_figures/ex_3.png")
 ```


### PR DESCRIPTION
filled out placeholder for _how_to_full_width.Rmd (#2). 

also added a few more examples for PDF/LaTeX tables. I received the same error as @geanders noted in #5 about Ghostscript (even though I have it installed), so I was not able to generate images for these tables using `kableExtra::as_image`. 

I rendered the PDF table examples in a normal Rmd and attached so you can see what they look like: 
[pdf_tables.pdf](https://github.com/sharlagelfand/kableExtra-cookbook/files/4514080/pdf_tables.pdf)


Thanks!
David